### PR TITLE
return what the user actually wanted to return

### DIFF
--- a/lib/pushpop-sendgrid.rb
+++ b/lib/pushpop-sendgrid.rb
@@ -28,7 +28,7 @@ module Pushpop
 
     def run(last_response=nil, step_responses=nil)
 
-      self.configure(last_response, step_responses)
+      ret = self.configure(last_response, step_responses)
 
       # print the message if its just a preview
       return print_preview if self._preview
@@ -42,6 +42,8 @@ module Pushpop
       if _to && _from && _subject && _body
         send_email(_to, _from, _subject, _body, _attachment)
       end
+
+      ret
     end
 
     def send_email(_to, _from, _subject, _body, _attachment)

--- a/lib/pushpop-sendgrid/version.rb
+++ b/lib/pushpop-sendgrid/version.rb
@@ -1,5 +1,5 @@
 module Pushpop
   class Sendgrid
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end


### PR DESCRIPTION
@hex337 Right now sendgrid steps return whatever `send_email` returns, which is falsey... that means there can never be any steps after a sendgrid step.

This updates it so the value actually returned by the user gets sent back to the job.